### PR TITLE
Adding Delphinus SUpport

### DIFF
--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,0 +1,16 @@
+{
+	"id": "{6A2DF212-41DC-4E7F-9AA0-8B31409BB543}",
+	"license_type": "Apache-2.0",
+	"license_file": "LICENSE.txt",
+	"platforms": "Win32;Win64",
+	"package_compiler_min": 22,
+	"compiler_min": 22,
+	"first_version": "0.0.3",
+	"dependencies":
+	[
+		{
+			"id": "{a43e7593-777a-4858-9ab6-085d845c0c55}",
+			"version_min": "3.7.2"
+		}
+	]
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,0 +1,18 @@
+{
+	"search_pathes": 
+	[
+		{
+			"pathes": ".\\Source",
+			"platforms": "Win32;Win64"
+		}
+	],
+	
+	"source_folders":
+	[
+		{
+			"folder": ".",
+			"recursive": true,
+			"filter": "*.*"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -120,3 +120,4 @@ begin
 ```
 
 Note that Await actually invokes the async function. There is also an overload to TAsync.Configure that does not take a cancellation token for when you don't need to cancel.
+Delphinus-Support

--- a/Source/VSoft.Awaitable.Impl.pas
+++ b/Source/VSoft.Awaitable.Impl.pas
@@ -31,7 +31,7 @@ unit VSoft.Awaitable.Impl;
 interface
 
 uses
-  System.SysUtils,
+  SysUtils,
   VSoft.Awaitable;
 
 type

--- a/Source/VSoft.Awaitable.pas
+++ b/Source/VSoft.Awaitable.pas
@@ -38,7 +38,7 @@ unit VSoft.Awaitable;
 interface
 
 uses
-  System.SysUtils;
+  SysUtils;
 
 type
   ///  ICancellationToken is passed to async methods


### PR DESCRIPTION
This Pullrequest adds support for Delphinus. In addition to that, i made it compileable under XE.
The "first_version" entry allows Delphinus to skip older non delphinus versions, once it's released. I just guessed 0.0.3. In this case it's the tag_name. One tag had the v prefix, the other hasn't. So i wen't without the V here.